### PR TITLE
Support for compile time disabling of SPD 

### DIFF
--- a/config.c
+++ b/config.c
@@ -10,6 +10,7 @@
 #include "test.h"
 #include "screen_buffer.h"
 #include "dmi.h"
+#include "spd.h"
 
 extern int bail, beepmode;
 extern struct tseq tseq[];
@@ -46,7 +47,9 @@ void get_config(void)
 		cprint(POP_Y+6,  POP_X+6, "(4) Core Selection");
 		cprint(POP_Y+7,  POP_X+6, "(5) Refresh Screen");
 		cprint(POP_Y+8,  POP_X+6, "(6) Display DMI Data");
+#ifndef SPD_DISABLED
 		cprint(POP_Y+9,  POP_X+6, "(7) Display SPD Data");
+#endif
 		cprint(POP_Y+11, POP_X+6, "(0) Continue");
 
 		/* Wait for key release */

--- a/config.h
+++ b/config.h
@@ -74,3 +74,7 @@
 
 /* Location of flashing '+' symbol */
 #define MEMTEST_PLUS_LOCATION 9
+
+/* SPD_DISABLED - disabled SPD data reading and usage
+*/
+//#define SPD_DISABLED

--- a/spd.c
+++ b/spd.c
@@ -4,16 +4,24 @@
  * http://www.canardpc.com - http://www.memtest.org
  */
 
+#include "spd.h" 
+#include "config.h"
+
+#ifndef SPD_DISABLED
+
 #include "stdint.h"
 #include "test.h"
 #include "io.h"
 #include "pci.h"
 #include "msr.h"
-#include "spd.h"
 #include "screen_buffer.h"
 #include "jedec_id.h"
 
 #define NULL 0
+
+#define AMD_INDEX_IO_PORT	0xCD6
+#define AMD_DATA_IO_PORT	0xCD7
+#define AMD_SMBUS_BASE_REG	0x2C
 
 #define SMBHSTSTS smbusbase
 #define SMBHSTCNT smbusbase + 2
@@ -22,6 +30,11 @@
 #define SMBHSTDAT smbusbase + 5
 
 extern void wait_keyup();
+
+int get_ddr2_module_size(int rank_density_byte, int rank_num_byte);
+int get_ddr3_module_size(int sdram_capacity, int prim_bus_width, int sdram_width, int ranks);
+char* convert_hex_to_char(unsigned hex_org);
+void sb800_get_smb(void);
 
 int smbdev, smbfun;
 unsigned short smbusbase;
@@ -546,3 +559,20 @@ char* convert_hex_to_char(unsigned hex_org) {
 
         return buf;
 }
+#else // SPD_DISABLED
+
+void show_spd(void)
+{
+	//
+	// Empty implementations if there is not SPD available
+	//
+}
+
+void get_spd_spec()
+{
+	//
+	// Empty implementations if there is not SPD available
+	//
+}
+
+#endif

--- a/spd.h
+++ b/spd.h
@@ -3,15 +3,12 @@
  * By Samuel DEMEULEMEESTER, sdemeule@memtest.org
  * http://www.canardpc.com - http://www.memtest.org
  */
-
-#define AMD_INDEX_IO_PORT	0xCD6
-#define AMD_DATA_IO_PORT	0xCD7
-#define AMD_SMBUS_BASE_REG	0x2C
+#ifndef _SPD_H_
+#define _SPD_H_
 
 void get_spd_spec(void);
-int get_ddr2_module_size(int rank_density_byte, int rank_num_byte);
-int get_ddr3_module_size(int sdram_capacity, int prim_bus_width, int sdram_width, int ranks);
-char* convert_hex_to_char(unsigned hex_org);
-void sb800_get_smb(void);
+void show_spd(void);
+
+#endif
 
 

--- a/test.h
+++ b/test.h
@@ -180,7 +180,6 @@ void parity_err(ulong edi, ulong esi);
 void start_config(void);
 void clear_screen(void);
 void paging_off(void);
-void show_spd(void);
 int map_page(unsigned long page);
 void *mapping(unsigned long page_address);
 void *emapping(unsigned long page_address);


### PR DESCRIPTION
(needed for platforms with soldered memory chips)
Patch includes cleanup of spd module interface allowing for its clean disabling.
Changes:
- Add SPD_DISABLED config option (config.h)
- Cleanup of spd module interface (movinf all private functions and variables do spd.c)
- Disable spd code when SPD_DISABLED option is set (spd.c)
- Hide 'Display SPD Data' option on the configuration screen is SPD_DISABLED (display.c)